### PR TITLE
Simply FacebookAuth public API

### DIFF
--- a/FacebookAuth/Base/FacebookAuth.swift
+++ b/FacebookAuth/Base/FacebookAuth.swift
@@ -44,9 +44,8 @@ public final class FacebookAuth: NSObject {
   
   var completionHandler: ((String?, FacebookAuth.Error?) -> Void)? = nil
   
-  public init(config: Config, viewController: UIViewController) {
+  public init(config: Config) {
     self.config = config
-    self.viewController = viewController
   }
   
   /// This method is responsible for handling the URL redirected from the Facebook authentication flow.

--- a/Tests/Base/FacebookAuthTests.swift
+++ b/Tests/Base/FacebookAuthTests.swift
@@ -17,7 +17,7 @@ final class FacebookAuthTests: XCTestCase {
   
   override func setUp() {
     config = FacebookAuth.Config(appID: "1234657")
-    facebookAuth = FacebookAuth(config: config, viewController: UIViewController())
+    facebookAuth = FacebookAuth(config: config)
   }
   
   // MARK: - openURL method


### PR DESCRIPTION
## Deletions

- Removes the unnecessary `viewController` parameter from the `FacebookAuth` initializer.