### PR TITLE
Add public init to FacebookAuth.Result

### DIFF
--- a/FacebookAuth/Base/FacebookAuth.swift
+++ b/FacebookAuth/Base/FacebookAuth.swift
@@ -80,6 +80,12 @@ public final class FacebookAuth: NSObject {
     public let token: String?
     public let error: FacebookAuth.Error?
     public let granted: [FacebookAuth.Permission]?
+    
+    public init(token: String?, error: FacebookAuth.Error?, granted: [FacebookAuth.Permission]?) {
+      self.token = token
+      self.error = error
+      self.granted = granted
+    }
   }
 
   public struct URLParser {


### PR DESCRIPTION
This will allow for better testability of host applications which need to mock the `authenticate` method.